### PR TITLE
Estimate audio sink frequency, reduce buffering latency and improve final mix resampling

### DIFF
--- a/src/emu/cosine.h
+++ b/src/emu/cosine.h
@@ -1,0 +1,76 @@
+// license:BSD-3-Clause
+// copyright-holders:intealls
+/***************************************************************************
+
+    cosine.h
+
+    Cosine resampling for final audio mix
+
+***************************************************************************/
+
+#ifndef SRC_EMU_COSINE_H_
+#define SRC_EMU_COSINE_H_
+
+class cosine_resampler
+{
+public:
+	cosine_resampler() : m_remainder(0.0)
+	{
+		for (int i = 0; i < n; i++)
+			table[i] = (1.0f - cosf((float)i / n * M_PI)) * 0.5f;
+	};
+
+	void apply(double rate, const int16_t* input, size_t input_frames, int16_t* output, size_t* output_frames, int num_channels)
+	{
+		*output_frames = ((float)input_frames) * rate + m_remainder;
+		m_remainder -= (int)m_remainder;
+
+		resample(input, input_frames, output, *output_frames, num_channels);
+		m_remainder += ((float)input_frames) * rate - *output_frames;
+	}
+private:
+	static const int n = 10000;
+	float table[n];
+	double m_remainder;
+
+	void resample(const int16_t* input, size_t input_frames, int16_t* output, size_t output_frames, int num_channels)
+	{
+		if (!input || !output || input_frames == 0 || output_frames == 0 || num_channels <= 0)
+			return;
+
+		float resample_factor = (float)output_frames / input_frames;
+
+		if (resample_factor <= 0.0f)
+			return;
+
+		float input_pos = 0.0f;
+
+		for (size_t out_idx = 0; out_idx < output_frames; ++out_idx) {
+			size_t in_idx = floorf(input_pos);
+			float frac = input_pos - in_idx;  // fractional part
+
+			// Clamp to avoid reading past the last sample
+			size_t in_idx_next =
+					(in_idx + 1 < input_frames) ? (in_idx + 1) : (input_frames - 1);
+
+			float mu = table[static_cast<int>(std::clamp<float>(frac, 0, 1) * (n - 1))];
+
+			for (int ch = 0; ch < num_channels; ++ch) {
+				float y1 = input[in_idx * num_channels + ch];
+				float y2 = input[in_idx_next * num_channels + ch];
+				float interpolated = y1 + (y2 - y1) * mu;
+
+				if (interpolated > 32767.0f)
+					interpolated = 32767.0f;
+				else if (interpolated < -32768.0f)
+					interpolated = -32768.0f;
+
+				output[out_idx * num_channels + ch] = interpolated;
+			}
+
+			input_pos += 1.0f / resample_factor;
+		}
+	}
+};
+
+#endif /* SRC_EMU_COSINE_H_ */

--- a/src/emu/emusync.cpp
+++ b/src/emu/emusync.cpp
@@ -210,7 +210,7 @@ void emusync::register_sink_samples(int id, uint64_t samples)
 //  emusync::sink_rate
 //============================================================
 
-double emusync::sink_rate(int id)
+double emusync::get_sink_rate(int id)
 {
 	auto sink_st = m_sinks.find(id);
 

--- a/src/emu/emusync.cpp
+++ b/src/emu/emusync.cpp
@@ -24,6 +24,15 @@
 
 static kalman_filter kf;
 
+//#define emusync_printf_verbose(...) osd_printf_verbose(__VA_ARGS__)
+#define emusync_printf_verbose(...)
+
+//#define emusync_printf_info(...) osd_printf_info(__VA_ARGS__)
+#define emusync_printf_info(...)
+
+//#define emusync_sinks_printf_verbose(...) osd_printf_verbose(__VA_ARGS__)
+#define emusync_sinks_printf_verbose(...)
+
 //============================================================
 //  emusync::emusync
 //============================================================
@@ -116,12 +125,11 @@ void emusync::register_tag(enum emusync::event_tag tag)
 			if (prev_timestamp != 0)
 			{
 				m_frame_time = m_timestamp[tag] - prev_timestamp;
-				uint64_t present_time = m_timestamp[AFTER_PRESENT] - m_timestamp[BEFORE_PRESENT];
-				osd_printf_verbose("present: %.3f emu_t: %.3f emu_t_avg: %.3f Dm: %.3f period: %.3f\n\n",
-					get_ms(present_time), get_ms(m_current_emulation_time), get_ms(m_emulation_time_avg), get_ms(m_emulation_time_dm), frame_time_in_ms());
+				emusync_printf_verbose("present: %.3f emu_t: %.3f emu_t_avg: %.3f Dm: %.3f period: %.3f\n\n",
+					get_ms(m_timestamp[AFTER_PRESENT] - m_timestamp[BEFORE_PRESENT]), get_ms(m_current_emulation_time), get_ms(m_emulation_time_avg), get_ms(m_emulation_time_dm), frame_time_in_ms());
 			}
 			else
-				osd_printf_verbose("\n");
+				emusync_printf_verbose("\n");
 
 			update_stats();
 			break;
@@ -177,6 +185,40 @@ void emusync::register_emutime(uint64_t emutime)
 	m_emulation_time_dm += diff_delta;
 }
 
+//============================================================
+//  emusync::register_sink_samples
+//============================================================
+
+void emusync::register_sink_samples(int id, uint64_t samples)
+{
+	double timestamp = time_now() / 1e3;
+
+	auto sink_st = m_sinks.find(id);
+
+	if (sink_st == m_sinks.end()) {
+		m_sinks.emplace(id, sink_status(timestamp, samples));
+		return;
+	}
+
+	sink_st->second.m_samples_out += samples;
+	sink_st->second.m_ef.update(timestamp, sink_st->second.m_samples_out);
+
+	emusync_sinks_printf_verbose("[%.3f][%d][%llu][%f] register_sink_samples\n", timestamp * 1e3, id, samples, sink_st->second.m_ef.slope());
+}
+
+//============================================================
+//  emusync::sink_rate
+//============================================================
+
+double emusync::sink_rate(int id)
+{
+	auto sink_st = m_sinks.find(id);
+
+	if (sink_st == m_sinks.end())
+		return 0.0;
+
+	return sink_st->second.m_ef.slope_out();
+}
 
 //============================================================
 //  emusync::register_vblank_in_ticks
@@ -197,7 +239,7 @@ bool emusync::register_vblank_in_ns(uint64_t sync_count, uint64_t timestamp)
 	int64_t delta;
 	int count_delta = 0;
 
-	osd_printf_verbose("[%.3f] register vblank: ", time_now());
+	emusync_printf_verbose("[%.3f] register vblank: ", time_now());
 
 	if (m_initialized)
 	{
@@ -206,7 +248,7 @@ bool emusync::register_vblank_in_ns(uint64_t sync_count, uint64_t timestamp)
 		// Skip sample if it's not newer. Big deltas may be inaccurate, discard.
 		if (count_delta == 0)
 		{
-			//osd_printf_verbose("count delta: %d\n", count_delta);
+			//emusync_printf_verbose("count delta: %d\n", count_delta);
 			goto register_and_exit;
 		}
 
@@ -220,20 +262,20 @@ bool emusync::register_vblank_in_ns(uint64_t sync_count, uint64_t timestamp)
 		// Filter timestamp. If needed, compute intermediate timestamps to feed the filter.
 		for (int i = count_delta; i > 0; --i) kf.update(timestamp - i * m_current_period);
 
-		//osd_printf_verbose("raw: %lld filtered: %lld diff: %+d period: %f\n", timestamp, kf.get_filtered_timestamp(),
+		//emusync_printf_verbose("raw: %lld filtered: %lld diff: %+d period: %f\n", timestamp, kf.get_filtered_timestamp(),
 		//					(int64_t)(timestamp - kf.get_filtered_timestamp()), get_ms(kf.get_period()));
 
 		delta = m_current_period - m_mean;
 
 		m_vblank_count++;
 		m_mean += delta / m_vblank_count;
-		osd_printf_verbose("[%.3f] sync: %d, period: %f, diff: %+f ms, mean: %f ms",
+		emusync_printf_verbose("[%.3f] sync: %d, period: %f, diff: %+f ms, mean: %f ms",
 			get_ms(timestamp - m_first_timestamp), sync_count - m_first_sync_count, get_ms(m_current_period), get_ms(delta), get_ms(m_mean));
 	}
 
 	if (!m_initialized)
 	{
-		osd_printf_verbose("initialize, sync_count %d", sync_count);
+		emusync_printf_verbose("initialize, sync_count %d", sync_count);
 		m_initialized = true;
 		m_first_sync_count = sync_count;
 		m_first_timestamp = timestamp;
@@ -242,9 +284,9 @@ bool emusync::register_vblank_in_ns(uint64_t sync_count, uint64_t timestamp)
 register_and_exit:
 
 	if(count_delta != 1)
-		osd_printf_verbose(" count_delta: %d\n", count_delta);
+		emusync_printf_verbose(" count_delta: %d\n", count_delta);
 	else
-		osd_printf_verbose("\n");
+		emusync_printf_verbose("\n");
 
 	m_last_count = sync_count - m_first_sync_count;
 	m_last_sync_count = sync_count;
@@ -267,12 +309,12 @@ uint64_t emusync::wait_raster(uint64_t count, double scan)
 
 	uint64_t time_entry = time_in_ns();
 
-	osd_printf_verbose("wait raster [%d][%.3f]: ", count, scan);
+	emusync_printf_verbose("wait raster [%d][%.3f]: ", count, scan);
 
 	// Wait for target time
 	if ((int)(time_target - time_entry) > 0)
 	{
-		osd_printf_verbose("must wait: %+.3f ", get_ms(time_target) - get_ms(time_entry));
+		emusync_printf_verbose("must wait: %+.3f ", get_ms(time_target) - get_ms(time_entry));
 
 		uint64_t current_time;
 		do
@@ -287,10 +329,10 @@ uint64_t emusync::wait_raster(uint64_t count, double scan)
 		} while ((current_time - time_entry) < period() * 2);
 	}
 	else
-		osd_printf_verbose("delayed, exiting. ");
+		emusync_printf_verbose("delayed, exiting. ");
 
 	uint64_t time_exit = time_in_ns();
-	osd_printf_verbose("elapsed: %.3f\n", get_ms(time_exit - time_entry));
+	emusync_printf_verbose("elapsed: %.3f\n", get_ms(time_exit - time_entry));
 
 	return time_exit - time_entry;
 }
@@ -359,7 +401,7 @@ void emusync::predraw_sync()
 
 	raster_status raster = {};
 	get_raster(&raster);
-	osd_printf_verbose("[%.3f] get raster->[%d][%.3f] ", time_now(), raster.count, raster.scan);
+	emusync_printf_verbose("[%.3f] get raster->[%d][%.3f] ", time_now(), raster.count, raster.scan);
 
 	m_this_sync_frame = raster.count;
 	m_missed_previous_retrace = m_this_sync_frame > m_next_sync_frame;
@@ -367,7 +409,7 @@ void emusync::predraw_sync()
 	if (handle_throttle() && machine().video().throttled() && !m_missed_previous_retrace)
 		m_predraw_sync_wait = wait_raster(raster.count, 0.90);
 	else
-		osd_printf_verbose("missed retrace\n");
+		emusync_printf_verbose("missed retrace\n");
 }
 
 
@@ -399,10 +441,10 @@ void emusync::postdraw_sync()
 
 	if (handle_throttle() && machine().video().throttled())
 	{
-		osd_printf_verbose("[%.3f] ", time_now());
+		emusync_printf_verbose("[%.3f] ", time_now());
 		m_postdraw_sync_wait = wait_raster(m_next_sync_frame, fd);
 	}
 
-	osd_printf_verbose("[%.3f] wait: %.3f ", time_now(), get_ms(m_predraw_sync_wait + m_postdraw_sync_wait));
+	emusync_printf_verbose("[%.3f] wait: %.3f ", time_now(), get_ms(m_predraw_sync_wait + m_postdraw_sync_wait));
 }
 

--- a/src/emu/emusync.h
+++ b/src/emu/emusync.h
@@ -45,7 +45,7 @@ public:
 	bool register_vblank_in_ns(uint64_t sync_count, uint64_t timestamp);
 	void register_emutime(uint64_t emutime);
 	void register_sink_samples(int id, uint64_t samples);
-	double sink_rate(int id);
+	double get_sink_rate(int id);
 	uint64_t wait_raster(uint64_t count, double scan);
 	void get_raster(raster_status *status);
 	void get_scanline(uint32_t *scanline, bool *in_vblank);

--- a/src/emu/emusync.h
+++ b/src/emu/emusync.h
@@ -9,6 +9,8 @@
 #ifndef MAME_EMU_SYNC_H
 #define MAME_EMU_SYNC_H
 
+#include "expfit.h"
+
 class emusync
 {
 public:
@@ -42,6 +44,8 @@ public:
 	bool register_vblank_in_ticks(uint64_t sync_count, uint64_t timestamp);
 	bool register_vblank_in_ns(uint64_t sync_count, uint64_t timestamp);
 	void register_emutime(uint64_t emutime);
+	void register_sink_samples(int id, uint64_t samples);
+	double sink_rate(int id);
 	uint64_t wait_raster(uint64_t count, double scan);
 	void get_raster(raster_status *status);
 	void get_scanline(uint32_t *scanline, bool *in_vblank);
@@ -78,6 +82,14 @@ public:
 	void set_vsync_offset(int vsync_offset) { m_vsync_offset = vsync_offset; }
 	void set_vtotal(int vtotal) { m_vtotal = vtotal; }
 
+	struct sink_status
+	{
+		uint64_t m_samples_out;
+		exp_fit m_ef;
+
+		sink_status(double timestamp, uint64_t samples_out) :
+			m_samples_out(samples_out), m_ef(exp_fit(0.025, timestamp, samples_out)) { }
+	};
 
 private:
 	running_machine &m_machine;
@@ -132,5 +144,7 @@ private:
 
 	std::function<void(void)> get_vblank_timestamp;
 	std::function<uint64_t(void)> get_frame_counter;
+
+	std::map<uint32_t, struct sink_status> m_sinks;
 };
 #endif

--- a/src/emu/expfit.h
+++ b/src/emu/expfit.h
@@ -1,0 +1,95 @@
+// license:BSD-3-Clause
+// copyright-holders:intealls
+/***************************************************************************
+
+    expfit.h
+
+    Linear regression with forgetting factor, allows for rolling adaptation
+    of estimate. Used to estimate actual audio sink frequency.
+
+***************************************************************************/
+
+#ifndef SRC_EMU_EXPFIT_H_
+#define SRC_EMU_EXPFIT_H_
+
+struct exp_fit
+{
+	double m_meanX;
+	double m_meanY;
+	double m_varX;
+	double m_covXY;
+	double m_n;
+	double m_meanXY;
+	double m_varY;
+	double m_alpha;
+
+	double m_x0;
+	double m_y0;
+
+	int m_lim;
+	double m_slope_lim;
+
+	exp_fit(double alpha, double x, double y)
+	{
+		m_alpha = alpha;
+		reset(x, y);
+
+		m_slope_lim = 0.0;
+
+		// use estimate when 1% of initial value remains
+		m_lim = std::log(0.01) / std::log(1.0 - alpha) + 0.5;
+	}
+
+	void reset(double x, double y)
+	{
+		m_x0 = x;
+		m_y0 = y;
+
+		m_meanX = 0;
+		m_meanY = 0;
+		m_varX = 0;
+		m_covXY = 0;
+		m_n = 0;
+		m_meanXY = 0;
+		m_varY = 0;
+
+		m_slope_lim = 0.0;
+	}
+
+	void update(double x, double y)
+	{
+		double xt = x - m_x0;
+		double yt = y - m_y0;
+
+		m_n += 1;
+
+		double alpha = std::max<double>(m_alpha, 1.0 / m_n);
+
+		double dx = xt - m_meanX;
+		double dy = yt - m_meanY;
+		double dxy = (xt * yt) - m_meanXY;
+
+		m_varX += ((1 - alpha) * dx * dx - m_varX) * alpha;
+		m_varY += ((1 - alpha) * dy * dy - m_varY) * alpha;
+		m_covXY += ((1 - alpha) * dx * dy - m_covXY) * alpha;
+
+		m_meanX += dx * alpha;
+		m_meanY += dy * alpha;
+		m_meanXY += dxy  * alpha;
+
+		if (m_n > m_lim)
+			m_slope_lim = slope();
+	}
+
+	double slope()
+	{
+		return m_covXY / m_varX;
+	}
+
+	double slope_out()
+	{
+		return m_slope_lim;
+	}
+};
+
+#endif /* SRC_EMU_EXPFIT_H_ */

--- a/src/emu/sound.cpp
+++ b/src/emu/sound.cpp
@@ -17,6 +17,7 @@
 #include "emuopts.h"
 #include "emusync.h"
 #include "main.h"
+#include "screen.h"
 #include "speaker.h"
 
 #include "wavwrite.h"
@@ -766,7 +767,14 @@ sound_manager::sound_manager(running_machine &machine) :
 
 	// start the periodic update flushing timer
 	m_update_timer = machine.scheduler().timer_alloc(timer_expired_delegate(FUNC(sound_manager::update), this));
-	m_update_timer->adjust(STREAMS_UPDATE_ATTOTIME, 0, STREAMS_UPDATE_ATTOTIME);
+	screen_device_enumerator iter(machine.root_device());
+	if (iter.first() == nullptr) {
+		// screenless
+		m_update_timer->adjust(STREAMS_UPDATE_ATTOTIME, 0, STREAMS_UPDATE_ATTOTIME);
+	} else {
+		attotime update_period = iter.first()->frame_period();
+		m_update_timer->adjust(update_period, 0, update_period);
+	}
 
 	// mark the generation as "just starting, waiting for config loading"
 	m_osd_info.m_generation = 0xffff0000;
@@ -1123,13 +1131,18 @@ void sound_manager::run_effects()
 
 		machine().osd().sound_begin_update();
 
-		// Send the result to the osd
+		// Resample streams and send to osd
 		for(auto &stream : m_osd_output_streams)
 			if(stream.m_samples) {
 				size_t output_frames;
 
-				double sink_rate = machine().sync().sink_rate(stream.m_id) / stream.m_rate;
-				double rate = (1000.0 / machine().video().speed_factor()) * (sink_rate == 0.0 ? 1.0 : sink_rate);
+				double rate = 1000.0 / machine().video().speed_factor();
+				double sink_rate = machine().sync().get_sink_rate(stream.m_id) / stream.m_rate;
+
+				if (machine().sync().handle_throttle() && machine().options().sync_audio())
+					rate = machine().sync().speed_factor();
+
+				rate *= sink_rate == 0.0 ? 1.0 : sink_rate;
 
 				stream.m_output_resampler.apply(rate, stream.m_buffer.data(), stream.m_samples, stream.m_output_buffer.data(), &output_frames, stream.m_channels);
 

--- a/src/emu/sound.cpp
+++ b/src/emu/sound.cpp
@@ -1029,58 +1029,19 @@ void sound_manager::run_effects()
 
 		std::unique_lock<std::mutex> lock(m_effects_mutex);
 #endif
-		// Copy the data to the effects threads, expanding as needed
-		// when -speed is in use
-		double sf = machine().video().speed_factor();
-		if(sf == 1000 && !(machine().sync().handle_throttle() && machine().options().sync_audio())) {
-			for(auto &si : m_speakers) {
-				int samples = si.m_buffer.available_samples();
-				int channels = si.m_buffer.channels();
-				auto &eb = si.m_effects_buffer;
-				eb.prepare_space(samples);
-				if(m_muted)
-					for(int channel = 0; channel != channels; channel ++)
-						std::fill(si.m_effects_buffer.ptrw(channel, 0), si.m_effects_buffer.ptrw(channel, 0) + samples, 0);
-				else
-					for(int channel = 0; channel != channels; channel ++)
-						std::copy(si.m_buffer.ptrs(channel, 0), si.m_buffer.ptrs(channel, 0) + samples, eb.ptrw(channel, 0));
-				eb.commit(samples);
-			}
-		} else {
-			if (machine().sync().handle_throttle() && machine().options().sync_audio())
-				sf = machine().sync().speed_factor();
+		// Copy the data to the effects threads
+		for(auto &si : m_speakers) {
+			int samples = si.m_buffer.available_samples();
+			int channels = si.m_buffer.channels();
+			auto &eb = si.m_effects_buffer;
+			eb.prepare_space(samples);
+			if(m_muted)
+				for(int channel = 0; channel != channels; channel ++)
+					std::fill(si.m_effects_buffer.ptrw(channel, 0), si.m_effects_buffer.ptrw(channel, 0) + samples, 0);
 			else
-				sf /= 1000;
-			for(auto &si : m_speakers) {
-				int source_samples = si.m_buffer.available_samples();
-				int channels = si.m_buffer.channels();
-				auto &eb = si.m_effects_buffer;
-				eb.prepare_space(source_samples / sf + 1);
-				int source_sample_index = 0;
-				int dest_index = 0;
-				double m_phase = si.m_speed_phase;
-				for(int channel = 0; channel != channels; channel ++) {
-					const sample_t *src = si.m_buffer.ptrs(channel, 0);
-					m_phase = si.m_speed_phase;
-					if(m_phase >= 1) {
-						source_sample_index = int(m_phase);
-						m_phase -= int(m_phase);
-					} else
-						source_sample_index = 0;
-					sample_t *dest = eb.ptrw(channel, 0);
-					dest_index = 0;
-					while(source_sample_index < source_samples) {
-						dest[dest_index++] = m_muted ? 0.0 : src[source_sample_index];
-						m_phase += sf;
-						if(m_phase >= 1) {
-							source_sample_index += int(m_phase);
-							m_phase -= int(m_phase);
-						}
-					}
-				}
-				si.m_speed_phase = m_phase + (source_sample_index - source_samples);
-				eb.commit(dest_index);
-			}
+				for(int channel = 0; channel != channels; channel ++)
+					std::copy(si.m_buffer.ptrs(channel, 0), si.m_buffer.ptrs(channel, 0) + samples, eb.ptrw(channel, 0));
+			eb.commit(samples);
 		}
 #ifndef SOUND_DISABLE_THREADING
 		dlock.unlock();
@@ -1164,8 +1125,16 @@ void sound_manager::run_effects()
 
 		// Send the result to the osd
 		for(auto &stream : m_osd_output_streams)
-			if(stream.m_samples)
-				machine().osd().sound_stream_sink_update(stream.m_id, stream.m_buffer.data(), stream.m_samples);
+			if(stream.m_samples) {
+				size_t output_frames;
+
+				double sink_rate = machine().sync().sink_rate(stream.m_id) / stream.m_rate;
+				double rate = (1000.0 / machine().video().speed_factor()) * (sink_rate == 0.0 ? 1.0 : sink_rate);
+
+				stream.m_output_resampler.apply(rate, stream.m_buffer.data(), stream.m_samples, stream.m_output_buffer.data(), &output_frames, stream.m_channels);
+
+				machine().osd().sound_stream_sink_update(stream.m_id, stream.m_output_buffer.data(), output_frames);
+			}
 
 		machine().osd().sound_end_update();
 #ifndef SOUND_DISABLE_THREADING

--- a/src/emu/sound.h
+++ b/src/emu/sound.h
@@ -67,6 +67,7 @@
 
 #include "wavwrite.h"
 #include "interface/audio.h"
+#include "cosine.h"
 
 #include <string>
 #include <string_view>
@@ -560,11 +561,16 @@ private:
 
 	struct osd_output_stream : public osd_stream {
 		u32 m_samples;
+		cosine_resampler m_output_resampler;
 		std::vector<s16> m_buffer;
+		std::vector<s16> m_output_buffer;
+
 		osd_output_stream(u32 node, std::string &&node_name, u32 channels, u32 rate, bool is_system_default, sound_io_device *dev) :
 			osd_stream(node, std::move(node_name), channels, rate, is_system_default, dev),
 			m_samples(0),
-			m_buffer(channels*rate, 0)
+			m_output_resampler(cosine_resampler()),
+			m_buffer(channels*rate, 0),
+			m_output_buffer(channels * rate, 0)
 		{ }
 	};
 

--- a/src/osd/modules/sound/pipewire_sound.cpp
+++ b/src/osd/modules/sound/pipewire_sound.cpp
@@ -16,6 +16,9 @@
 #define GNU_SOURCE
 #include "modules/lib/osdobj_common.h"
 
+#include "emu.h"
+#include "emusync.h"
+
 #include <pipewire/pipewire.h>
 #include <pipewire/extensions/metadata.h>
 #include <spa/debug/pod.h>
@@ -160,6 +163,8 @@ private:
 
 	void stream_event_param_changed(stream_info *stream, uint32_t id, const spa_pod *param);
 	static void s_stream_event_param_changed(void *data, uint32_t id, const spa_pod *param);
+
+	emusync* m_emusync;
 };
 
 // Try to more or less map to speaker.h positions
@@ -513,6 +518,8 @@ int sound_pipewire::init(osd_interface &osd, osd_options const &options)
 	sync();
 	sync();
 
+	m_emusync = &downcast<osd_common_t &>(osd).machine().sync();
+
 	return 0;
 }
 
@@ -607,6 +614,7 @@ void sound_pipewire::stream_sink_event_process(stream_info *stream)
 		return;
 
 	spa_buffer *sbuf = buffer->buffer;
+	m_emusync->register_sink_samples(stream->m_osdid, buffer->requested);
 	stream->m_buffer.get((int16_t *)(sbuf->datas[0].data), buffer->requested);
 
 	sbuf->datas[0].chunk->offset = 0;

--- a/src/osd/modules/sound/sdl_sound.cpp
+++ b/src/osd/modules/sound/sdl_sound.cpp
@@ -12,6 +12,9 @@
 
 #include "modules/osdmodule.h"
 
+#include "emu.h"
+#include "emusync.h"
+
 #if (defined(OSD_SDL) || defined(USE_SDL_SOUND))
 
 #include "modules/lib/osdobj_common.h"
@@ -66,12 +69,14 @@ private:
 		uint32_t m_id;
 		SDL_AudioDeviceID m_sdl_id;
 		abuffer m_buffer;
-		stream_info(uint32_t id, uint8_t channels) : m_id(id), m_sdl_id(0), m_buffer(channels) {}
+		emusync* m_emusync;
+		stream_info(uint32_t id, uint8_t channels, emusync* emusync) : m_id(id), m_sdl_id(0), m_buffer(channels), m_emusync(emusync) {}
 	};
 
 	std::vector<device_info> m_devices;
 	uint32_t m_default_sink;
 	uint32_t m_stream_next_id;
+	emusync* m_emusync;
 
 	std::map<uint32_t, std::unique_ptr<stream_info>> m_streams;
 
@@ -132,6 +137,7 @@ int sound_sdl::init(osd_interface &osd, const osd_options &options)
 		SDL_free(def_name);
 	}
 #endif
+	m_emusync = &downcast<osd_common_t &>(osd).machine().sync();
 	return 0;
 }
 
@@ -202,7 +208,7 @@ osd::audio_info sound_sdl::get_information()
 uint32_t sound_sdl::stream_sink_open(uint32_t node, std::string name, uint32_t rate)
 {
 	device_info &dev = m_devices[node-1];
-	std::unique_ptr<stream_info> stream = std::make_unique<stream_info>(m_stream_next_id ++, dev.m_channels);
+	std::unique_ptr<stream_info> stream = std::make_unique<stream_info>(m_stream_next_id ++, dev.m_channels, m_emusync);
 
 	SDL_AudioSpec dspec, ospec;
 	dspec.freq = rate;
@@ -244,6 +250,7 @@ void sound_sdl::stream_sink_update(uint32_t id, const int16_t *buffer, int sampl
 void sound_sdl::sink_callback(void *userdata, uint8_t *data, int len)
 {
 	stream_info *stream = reinterpret_cast<stream_info *>(userdata);
+	stream->m_emusync->register_sink_samples(stream->m_id, len / 2 / stream->m_buffer.channels());
 	stream->m_buffer.get((int16_t *)data, len / 2 / stream->m_buffer.channels());
 }
 

--- a/src/osd/modules/sound/sound_module.cpp
+++ b/src/osd/modules/sound/sound_module.cpp
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:O. Galibert
+// copyright-holders:O. Galibert, intealls
 
 
 #include "sound_module.h"
@@ -8,26 +8,26 @@
 #include <cassert>
 #include <utility>
 
-
 sound_module::~sound_module()
 {
 	// implementing this here forces the vtable and inline virtual member functions to be instantiated
 }
 
-sound_module::abuffer::abuffer(uint32_t channels) noexcept : m_channels(channels), m_used_buffers(0), m_last_sample(channels, 0)
+sound_module::abuffer::abuffer(uint32_t channels) noexcept : m_channels(channels), m_used_buffers(0), m_unused_buffers(0), m_last_sample(channels, 0)
 {
-	m_delta = 0;
-	m_delta2 = 0;
+	m_buf_maintenance = osd_ticks();
+	m_start_ticks = m_buf_maintenance;
 }
 
 void sound_module::abuffer::get(int16_t *data, uint32_t samples) noexcept
 {
-	m_delta -= samples;
-	m_delta2 -= samples;
+	osd_ticks_t ticks_now = osd_ticks();
+	double d_ticks_now = (double)(ticks_now - m_start_ticks) / osd_ticks_per_second();
+
 	uint32_t pos = 0;
 	while(pos != samples) {
 		if(!m_used_buffers) {
-			m_delta2 += samples - pos;
+			//osd_printf_verbose("%f: underflow\n", d_ticks_now);
 			while(pos != samples) {
 				std::copy_n(m_last_sample.data(), m_channels, data);
 				data += m_channels;
@@ -55,36 +55,39 @@ void sound_module::abuffer::get(int16_t *data, uint32_t samples) noexcept
 		pos += avail;
 		data += avail * m_channels;
 	}
-	//  printf("# %d %d\n", m_delta, m_delta2);
+
+	// this tracks the number of unused buffers (which can be dropped safely)
+	m_unused_buffers = (m_used_buffers < m_unused_buffers) ? m_used_buffers : m_unused_buffers;
+
+	if (ticks_now - m_buf_maintenance > 2 * osd_ticks_per_second()) {
+		m_unused_buffers = m_used_buffers;
+		m_buf_maintenance = ticks_now;
+	}
+
+	//osd_printf_verbose("9999.9999, %d, %d, %d\n", available(), m_used_buffers, m_unused_buffers);
 }
 
 void sound_module::abuffer::push(const int16_t *data, uint32_t samples)
 {
-	m_delta += samples;
-	m_delta2 += samples;
 	auto &buf = push_buffer();
+
+	const int buf_safety_margin = 2;
+	const int buf_keep = std::min<int>(std::max<int>(m_used_buffers - m_unused_buffers + buf_safety_margin, 0), 5);
+
 	buf.m_cpos = 0;
 	buf.m_data.resize(samples * m_channels);
 	std::copy_n(data, samples * m_channels, buf.m_data.data());
 	std::copy_n(data + ((samples - 1) * m_channels), m_channels, m_last_sample.data());
 
-	if(m_used_buffers > 10) {
-		for(uint32_t i=0; i != m_used_buffers-10; i++)
-			m_delta2 -= (m_buffers[i].m_data.size()/m_channels - m_buffers[i].m_cpos);
-		// If there are way too many buffers, drop some so only 10 are left (roughly 0.2s)
-		for(unsigned i = 0; 10 > i; ++i) {
+	if(m_used_buffers > buf_keep) {
+		// If there are too many buffers, drop so we only keep the number we need (reduces latency)
+		for(unsigned i = 0; i < buf_keep; i++) {
 			using std::swap;
-			swap(m_buffers[i], m_buffers[m_used_buffers + i - 10]);
+			swap(m_buffers[i], m_buffers[m_used_buffers + i - buf_keep]);
 		}
-		m_used_buffers = 10;
-	} else if(m_used_buffers >= 5) {
-		// If there are too many buffers, remove five samples per buffer
-		// to slowly resync to reduce latency (4 seconds to
-		// compensate one buffer, roughly)
-		m_delta2 -= std::max<uint32_t>(samples / 200, 1);
-		buf.m_cpos = std::max<uint32_t>(samples / 200, 1);
+		//osd_printf_verbose("%f: overflow, used: %d, unused: %d, dropping %d\n", (double)(osd_ticks() - m_start_ticks) / osd_ticks_per_second(), m_used_buffers, m_unused_buffers, m_used_buffers - buf_keep);
+		m_used_buffers = buf_keep;
 	}
-	//  printf("# %d %d\n", m_delta, m_delta2);
 }
 
 uint32_t sound_module::abuffer::available() const noexcept

--- a/src/osd/modules/sound/sound_module.cpp
+++ b/src/osd/modules/sound/sound_module.cpp
@@ -22,7 +22,7 @@ sound_module::abuffer::abuffer(uint32_t channels) noexcept : m_channels(channels
 void sound_module::abuffer::get(int16_t *data, uint32_t samples) noexcept
 {
 	osd_ticks_t ticks_now = osd_ticks();
-	double d_ticks_now = (double)(ticks_now - m_start_ticks) / osd_ticks_per_second();
+	//double d_ticks_now = (double)(ticks_now - m_start_ticks) / osd_ticks_per_second();
 
 	uint32_t pos = 0;
 	while(pos != samples) {

--- a/src/osd/modules/sound/sound_module.h
+++ b/src/osd/modules/sound/sound_module.h
@@ -16,6 +16,8 @@
 #include <string>
 #include <vector>
 
+#include "osdcore.h"
+
 #define OSD_SOUND_PROVIDER   "sound"
 
 class sound_module
@@ -63,9 +65,11 @@ protected:
 		void pop_buffer() noexcept;
 		buffer &push_buffer();
 
-		int32_t m_delta, m_delta2;
+		osd_ticks_t m_buf_maintenance;
+		osd_ticks_t m_start_ticks;
 		uint32_t m_channels;
-		uint32_t m_used_buffers;
+		int m_used_buffers;
+		int m_unused_buffers;
 		std::vector<int16_t> m_last_sample;
 		std::vector<buffer> m_buffers;
 	};

--- a/src/osd/modules/sound/wasapi_sound.cpp
+++ b/src/osd/modules/sound/wasapi_sound.cpp
@@ -12,6 +12,9 @@
 
 #if defined(OSD_WINDOWS) | defined(SDLMAME_WIN32)
 
+#include "emu.h"
+#include "emusync.h"
+
 // local headers
 #include "mmdevice_helpers.h"
 
@@ -49,7 +52,6 @@
 #include <functiondiscoverykeys_devpkey.h>
 #include <mmdeviceapi.h>
 #include <mmreg.h>
-
 
 namespace osd {
 
@@ -220,6 +222,8 @@ private:
 	float                       m_audio_latency = 0.0F;
 	uint32_t                    m_generation = 1;
 	bool                        m_exiting = false;
+
+	emusync* m_emusync;
 };
 
 
@@ -420,6 +424,7 @@ void sound_wasapi::stream_info::render_task()
 			{
 				auto const available = m_buffer.available();
 				auto *samples = reinterpret_cast<int16_t *>(data);
+				m_host.m_emusync->register_sink_samples(info.m_node, locked);
 				if (!m_underflowing)
 				{
 					m_buffer.get(samples, locked);
@@ -683,6 +688,8 @@ int sound_wasapi::init(osd_interface &osd, osd_options const &options)
 	// start a thread to clean up removed streams
 	m_updated_devices.reserve(m_device_info.size() * 4); // hopefully avoid reallocations
 	m_housekeeping_thread = std::thread([] (sound_wasapi *self) { self->housekeeping_task(); }, this);
+
+	m_emusync = &downcast<osd_common_t &>(osd).machine().sync();
 
 	return 0;
 


### PR DESCRIPTION
Audio changes:

* Estimates audio sink frequency and takes this into account when resampling the final mix, should lead to fewer crackles.
* Adaptively reduce buffering latency, removes periodic crackling in certain conditions and lowers latency.
* Improve final mix sink resampling, instead of zero order hold (which creates audible crackling) we use cosine interpolation which sounds nicer.